### PR TITLE
[E2B-76] - Add test for compliance with the agent protocol

### DIFF
--- a/agent/python/agent_protocol/agent.py
+++ b/agent/python/agent_protocol/agent.py
@@ -54,7 +54,7 @@ async def create_agent_task(body: TaskRequestBody | None = None) -> Task:
 
 
 @app.get("/agent/tasks", response_model=List[str], tags=["agent", "tasks"])
-async def list_agent_tasks_i_ds() -> List[str]:
+async def list_agent_tasks_ids() -> List[str]:
     """
     List all tasks that have been created for the agent.
     """

--- a/agent/python/agent_protocol/tests/compliance.py
+++ b/agent/python/agent_protocol/tests/compliance.py
@@ -1,0 +1,68 @@
+import pytest
+import requests
+
+from agent_protocol.models import StepRequestBody, TaskRequestBody, Task, Step
+
+
+BASE_URL = "http://localhost:8000"
+
+
+class TestCompliance:
+    @property
+    def task_data(self) -> dict:
+        return TaskRequestBody(input="test").dict()
+
+    def test_create_agent_task(self):
+        response = requests.post(f"{BASE_URL}/agent/tasks", json=self.task_data)
+        assert response.status_code == 200
+        assert Task(**response.json()).task_id
+
+    def test_list_agent_tasks_ids(self):
+        response = requests.get(f"{BASE_URL}/agent/tasks")
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
+
+    def test_get_agent_task(self):
+        # Create task
+        response = requests.post(f"{BASE_URL}/agent/tasks", json=self.task_data)
+        task_id = response.json()["task_id"]
+        response = requests.get(f"{BASE_URL}/agent/tasks/{task_id}")
+        assert response.status_code == 200
+        assert Task(**response.json()).task_id == task_id
+
+    def test_list_agent_task_steps(self):
+        # Create task
+        response = requests.post(f"{BASE_URL}/agent/tasks", json=self.task_data)
+        task_id = response.json()["task_id"]
+        response = requests.get(f"{BASE_URL}/agent/tasks/{task_id}/steps")
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
+
+    def test_execute_agent_task_step(self):
+        # Create task
+        response = requests.post(f"{BASE_URL}/agent/tasks", json=self.task_data)
+        task_id = response.json()["task_id"]
+        step_body = StepRequestBody(input="test")
+        response = requests.post(f"{BASE_URL}/agent/tasks/{task_id}/steps", json=step_body.dict())
+        assert response.status_code == 200
+
+    @pytest.mark.skip("There is no way to be sure any step exists")
+    def test_get_agent_task_step(self):
+        # Create task
+        response = requests.post(f"{BASE_URL}agent/tasks", json=self.task_data)
+        task_id = response.json()["task_id"]
+        # Get steps
+        response = requests.get(f"{BASE_URL}/agent/tasks/{task_id}/steps")
+        step_id = response.json()["step_id"]
+        response = requests.get(f"{BASE_URL}/agent/tasks/{task_id}/steps/{step_id}")
+        assert response.status_code == 200
+        assert response.json()["step_id"] == step_id
+        Step(**response.json())
+
+
+def main():
+    pytest.main(["-v", __file__])
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/python/poetry.lock
+++ b/agent/python/poetry.lock
@@ -603,6 +603,17 @@ docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)
 testing = ["pygments", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
 name = "isort"
 version = "5.11.5"
 description = "A Python utility / library to sort Python imports."
@@ -897,6 +908,24 @@ docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.2.1)", "sphinx-
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
+name = "pluggy"
+version = "1.2.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
+    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
+]
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "prance"
 version = "0.21.8.0"
 description = "Resolving Swagger/OpenAPI 2.0 and 3.0.0 Parser"
@@ -1049,6 +1078,29 @@ files = [
 
 [package.extras]
 tests = ["pytest"]
+
+[[package]]
+name = "pytest"
+version = "7.4.0"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
+    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pyyaml"
@@ -1430,4 +1482,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7, <4.0.0"
-content-hash = "9cf71cce0163ceae789e056ae53add31d7fd3fb983dcea61b817964ba9c36f1e"
+content-hash = "d08047013a89c263541d280319b6924ebf51c4e88e6d1922436cbf4b1e3d08ba"

--- a/agent/python/pyproject.toml
+++ b/agent/python/pyproject.toml
@@ -13,6 +13,7 @@ packages = [{ include = "agent_protocol" }]
 python = ">=3.7, <4.0.0"
 fastapi = "^0.100.0"
 hypercorn = "^0.14.4"
+pytest = "^7.4.0"
 
 [tool.poetry.group.dev.dependencies]
 fastapi-code-generator = "^0.4.2"
@@ -22,7 +23,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-src = "src.__main__:main"
+agent-protocol = "agent_protocol.tests.compliance:main"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/e2b-dev/agent-protocol/issues"


### PR DESCRIPTION
The test can be triggered by running 

```shell
agent-protocol
```

Should I make it more future proof with something like?
```shell
agent-protocol --test
```
